### PR TITLE
Show file when staged to add but deleted in working tree

### DIFF
--- a/src/command/status.ts
+++ b/src/command/status.ts
@@ -105,19 +105,6 @@ export async function getStatus(
         if (entry.kind === 'entry') {
             const status = mapStatus(entry.statusCode);
 
-            if (status.kind === 'untracked') {
-                // when a delete has been staged, but an untracked file exists with the
-                // same path, we should ensure that we only draw one entry in the
-                // changes list - see if an entry already exists for this path and
-                // remove it if found
-                if (existingFiles.has(entry.path)) {
-                    const existingEntry = files.findIndex(p => p.path === entry.path);
-                    if (existingEntry > -1) {
-                        files.splice(existingEntry, 1);
-                    }
-                }
-            }
-
             // for now we just poke at the existing summary
             const summary = convertToAppStatus(status);
             const selection = DiffSelection.fromInitialSelection(

--- a/src/command/status.ts
+++ b/src/command/status.ts
@@ -1,7 +1,7 @@
 import { git, gitVersion, IGitExecutionOptions } from '../core/git';
 import { parsePorcelainStatus, mapStatus } from '../parser/status-parser';
 import { DiffSelectionType, DiffSelection } from '../model/diff';
-import { IStatusResult, IAheadBehind, WorkingDirectoryStatus, WorkingDirectoryFileChange, AppFileStatus, FileEntry, GitStatusEntry } from '../model/status';
+import { IStatusResult, IAheadBehind, WorkingDirectoryStatus, WorkingDirectoryFileChange, AppFileStatus, FileEntry } from '../model/status';
 
 function convertToAppStatus(status: FileEntry): AppFileStatus {
     if (status.kind === 'ordinary') {
@@ -104,18 +104,6 @@ export async function getStatus(
     for (const entry of entries) {
         if (entry.kind === 'entry') {
             const status = mapStatus(entry.statusCode);
-
-            if (status.kind === 'ordinary') {
-                // when a file is added in the index but then removed in the working
-                // directory, the file won't be part of the commit, so we can skip
-                // displaying this entry in the changes list
-                if (
-                    status.index === GitStatusEntry.Added &&
-                    status.workingTree === GitStatusEntry.Deleted
-                ) {
-                    continue;
-                }
-            }
 
             if (status.kind === 'untracked') {
                 // when a delete has been staged, but an untracked file exists with the


### PR DESCRIPTION
This is the fix for https://github.com/eclipse-theia/theia/issues/7789 .

If a file is created, then staged, then deleted, it is still staged for add (being in the index) and will be included in the commit.  Changes that have been made to the working tree but not staged will not be included in the commit, this includes the deletion of the file.

In this screenshot Untitled2.txt is now shown added in the staged area and deleted in the unstaged area.  Before it was not shown in either area, even though the add was being included in the commit.

![Screenshot from 2020-06-02 11-46-19](https://user-images.githubusercontent.com/87310/83512875-c7c1c200-a4c8-11ea-8fdc-5bc3dbece575.png)
